### PR TITLE
fixing utf8 smartquote issue

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -71,7 +71,7 @@
 #
 # [*ldap_user_principal*]
 # Optional. String. Defaults to "userPrincipalName".
-# The LDAP attribute that contains the user´s Kerberos User Principle.
+# The LDAP attribute that contains the user's Kerberos User Principle.
 #
 # [*ldap_user_uid_number*]
 # Optional. String. Defaults to "uidNumber".


### PR DESCRIPTION
puppet seems to hate the smartquote, changed to normal ascii single quote
