### PR TITLE
ldap compatibility update

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -1,4 +1,4 @@
-# == Define: sssd::domain
+# Define: sssd::domain
 # This type is used to define one or more domains which SSSD
 # will authenticate against.
 #
@@ -43,7 +43,7 @@
 # An optional base DN to restrict group searches to a specific subtree.
 #
 # [*krb5_realm*]
-# Required. String.
+# Optional. String.
 # This setting is only used if "krb5" is one of the providers.
 # SSSD does not use the settings from /etc/krb5.conf.
 #
@@ -71,7 +71,7 @@
 #
 # [*ldap_user_principal*]
 # Optional. String. Defaults to "userPrincipalName".
-# The LDAP attribute that contains the user´s Kerberos User Principle.
+# The LDAP attribute that contains the userÂ´s Kerberos User Principle.
 #
 # [*ldap_user_uid_number*]
 # Optional. String. Defaults to "uidNumber".
@@ -108,7 +108,7 @@
 # TLS encryption is maybe handled by OpenLDAP, I think.
 #
 # [*ldap_tls_reqcert*]
-# (demand|hard) Optional. String. Defaults to "demand".
+# (demand|hard|never|allow) Optional. String. Defaults to "demand".
 # How should sssd treat bad certificates from the server? In almost all cases,
 # sssd should demand a trusted certificate, otherwise terminate the connection.
 #
@@ -197,7 +197,7 @@ define sssd::domain (
   $ldap_user_search_base=$ldap_search_base,
   $ldap_group_search_base=$ldap_search_base,
   $ldap_netgroup_search_base=$ldap_search_base,
-  $krb5_realm,
+  $krb5_realm = '',
 
   $ldap_default_bind_dn,
   $ldap_default_authtok,
@@ -230,6 +230,7 @@ define sssd::domain (
   $min_id = undef,
   $entry_cache_timeout = 60,
   $krb5_canonicalize = false,
+  $ldap_access_filter = '',
 ) {
   validate_array($simple_allow_groups)
   validate_bool($ldap_id_use_start_tls)

--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -170,6 +170,32 @@
 # When using Kerberos with Active Directory, canonicalization should be set
 # to false so that cached credentials work properly.
 #
+# [*ldap_access_filter*]
+# Optional. String. Defaults is blank.
+# This specifies an accses filter to be used to allow access to the server.
+#
+# [*auth_provider*]
+# (krb5|ldap|ad) Optional. String. Defaults is krb5.
+# The authentication provider used for the domain.
+#
+# [*chpass_provider*]
+# (krb5|ldap|ad|none) Optional. String. Defaults is krb5.
+# The provider which should handle change password operations for the domain
+#
+# [*access_provider*]
+# (simple|ad|ldap|permit|deby) Optional. String. Defaults is simple.
+# The access control provider used for the domain.
+#
+# [*case_sensitive*]
+# (true|false) Optional. Boolean. Defaults is true.
+# Treat user and group names as case sensitive.
+#
+# [*ldap_id_mapping*]
+# (true|false) Optional. Boolean. Defaults is true.
+# By default, the AD provider will map UID and GID values from the objectSID parameter in Active Directory.
+# If you want to disable ID mapping and instead rely on POSIX attributes defined in Active Directory, 
+# you should set to false
+# 
 # === Requires
 # - [ripienaar/concat]
 # - [puppetlab/stdlib]
@@ -231,6 +257,13 @@ define sssd::domain (
   $entry_cache_timeout = 60,
   $krb5_canonicalize = false,
   $ldap_access_filter = '',
+
+  $auth_provider = 'krb5',
+  $chpass_provider = 'krb5',
+  $access_provider = 'simple',
+  $case_sensitive = true,
+  $ldap_id_mapping = true,
+
 ) {
   validate_array($simple_allow_groups)
   validate_bool($ldap_id_use_start_tls)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,11 +59,13 @@ class sssd (
     ensure      => installed,
   }
   
+  # SSSD fails to start if file mode is anything other than 0600
   concat { 'sssd_conf':
-    path        => '/etc/sssd/sssd.conf',
-    mode        => '0600',
-    # SSSD fails to start if file mode is anything other than 0600
-    require     => Package['sssd'],
+    path    => '/etc/sssd/sssd.conf',
+    mode    => '0600',
+    owner   => 'root',
+    group   => 'root',
+    require => Package['sssd'],
   }
   
   concat::fragment{ 'sssd_conf_header':

--- a/templates/domain.conf.erb
+++ b/templates/domain.conf.erb
@@ -1,9 +1,9 @@
 [domain/<%= @ldap_domain %>]
 id_provider = ldap
-auth_provider = ldap
-chpass_provider = ldap
-access_provider = ldap
-case_sensitive = False
+auth_provider = <%= @auth_provider %>
+chpass_provider = <%= @chpass_provider %>
+access_provider = <%= @access_provider %>
+case_sensitive = <%= @case_sensitive %>
 simple_allow_groups = <%= @simple_allow_groups.flatten.join(',') %>
 cache_credentials = <%= @cache_credentials %>
 min_id = <%= @real_min_id %>
@@ -17,14 +17,14 @@ ldap_group_search_base = <%= @ldap_group_search_base %>
 ldap_netgroup_search_base = <%= @ldap_netgroup_search_base %>
 ldap_referrals = <%= @ldap_referrals %>
 enumerate = <%= @enumerate %>
-ldap_access_filter = <%= ldap_access_filter %>
+ldap_access_filter = <%= @ldap_access_filter %>
 ldap_force_upper_case_realm = <%= @ldap_force_upper_case_realm %>
 ldap_schema = <%= @ldap_schema %>
 ldap_default_bind_dn = <%= @ldap_default_bind_dn %>
 ldap_default_authtok_type = <%= @ldap_default_authtok_type %>
 ldap_default_authtok = <%= @ldap_default_authtok %>
 ldap_id_use_start_tls = <%= @ldap_id_use_start_tls %>
-ldap_id_mapping = True
+ldap_id_mapping = <%= @ldap_id_mapping %>
 ldap_tls_reqcert = <%= @ldap_tls_reqcert %>
 <% if @ldap_tls_cacert_path -%>
 ldap_tls_cacert = <%= @ldap_tls_cacert_path %>

--- a/templates/domain.conf.erb
+++ b/templates/domain.conf.erb
@@ -1,5 +1,4 @@
 [domain/<%= @ldap_domain %>]
-debug_level = 5
 id_provider = ldap
 auth_provider = ldap
 chpass_provider = ldap

--- a/templates/domain.conf.erb
+++ b/templates/domain.conf.erb
@@ -1,8 +1,10 @@
 [domain/<%= @ldap_domain %>]
+debug_level = 5
 id_provider = ldap
-auth_provider = krb5
-chpass_provider = krb5
-access_provider = simple
+auth_provider = ldap
+chpass_provider = ldap
+access_provider = ldap
+case_sensitive = False
 simple_allow_groups = <%= @simple_allow_groups.flatten.join(',') %>
 cache_credentials = <%= @cache_credentials %>
 min_id = <%= @real_min_id %>
@@ -16,12 +18,14 @@ ldap_group_search_base = <%= @ldap_group_search_base %>
 ldap_netgroup_search_base = <%= @ldap_netgroup_search_base %>
 ldap_referrals = <%= @ldap_referrals %>
 enumerate = <%= @enumerate %>
+ldap_access_filter = <%= ldap_access_filter %>
 ldap_force_upper_case_realm = <%= @ldap_force_upper_case_realm %>
 ldap_schema = <%= @ldap_schema %>
 ldap_default_bind_dn = <%= @ldap_default_bind_dn %>
 ldap_default_authtok_type = <%= @ldap_default_authtok_type %>
 ldap_default_authtok = <%= @ldap_default_authtok %>
 ldap_id_use_start_tls = <%= @ldap_id_use_start_tls %>
+ldap_id_mapping = True
 ldap_tls_reqcert = <%= @ldap_tls_reqcert %>
 <% if @ldap_tls_cacert_path -%>
 ldap_tls_cacert = <%= @ldap_tls_cacert_path %>


### PR DESCRIPTION
These changes allow for use with a provider other than kerberos. some parameters were added into this so that auth_provider,id_provider,access_provider can be changed. Defaults are kept to the kerberos settings so that nothing that is using this currently should be effected by these changes.
